### PR TITLE
git: track indexed modified changes

### DIFF
--- a/src/git.c
+++ b/src/git.c
@@ -83,7 +83,8 @@ git_get_info(vccontext_t *context)
             if (context->options->show_unknown && *ch == '?') {
                 result->unknown = 1;
             }
-            else if (context->options->show_modified && *(ch+1) != ' ') {
+            else if (context->options->show_modified &&
+						(*(ch+1) != ' ') || *(ch) != ' ') {
                 result->modified = 1;
             }
         }


### PR DESCRIPTION
git-status short format's first column tracks index changes. ex: git-rm
git-add etc...

Check indexed second assuming there's more working tree changes than
indexed.